### PR TITLE
[自动化录入]有关“四人帮”在七机部的代理人舒龙山叶正光曹光琳及其资产阶级帮派体系罪行的部分材料（19775）

### DIFF
--- a/b8cb3a84-bba2-4d8c-9a55-f8d57062cebf.ts
+++ b/b8cb3a84-bba2-4d8c-9a55-f8d57062cebf.ts
@@ -1,0 +1,46 @@
+export default {
+  resource_type: 'book',
+  entity: {
+    id: 'b8cb3a84-bba2-4d8c-9a55-f8d57062cebf',
+    name: '有关“四人帮”在七机部的代理人舒龙山叶正光曹光琳及其资产阶级帮派体系罪行的部分材料（1977.5）',
+    internal: false,
+    official: false,
+    type: 'img',
+    author: '第七机械工业部政治部印',
+    files: ["https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/1.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/2.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/3.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/4.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/5.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/6.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/7.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/8.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/9.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/10.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/11.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/12.jpg","https://raw.githubusercontent.com/banned-historical-archives/banned-historical-archives1/main/13.jpg"]
+  },
+  parser_option: {
+  "articles": [
+    {
+      "title": "有关“四人帮”在七机部的代理人舒龙山叶正光曹光琳及其资产阶级帮派体系罪行的部分材料",
+      "authors": [
+        "七机部政治部"
+      ],
+      "page_start": 2,
+      "page_end": 13,
+      "dates": [
+        {
+          "year": 1977,
+          "month": 5
+        }
+      ]
+    }
+  ],
+  "ocr": {
+    "auto_vsplit": true,
+    "vsplit": 0.5,
+    "content_thresholds": [
+      0,
+      0,
+      0,
+      0
+    ],
+    "line_merge_threshold": 30,
+    "standard_paragraph_merge_strategy_threshold": 0,
+    "differential_paragraph_merge_strategy_threshold": 30
+  },
+  "ocr_exceptions": {}
+},
+  parser_id: 'automation',
+  path: 'b8cb3a84-bba2-4d8c-9a55-f8d57062cebf'
+};


### PR DESCRIPTION
close https://github.com/banned-historical-archives/banned-historical-archives.github.io/issues/3922